### PR TITLE
[Feat] 내 정보 페이지 UI 구현

### DIFF
--- a/src/app/myPage/myPage.css.ts
+++ b/src/app/myPage/myPage.css.ts
@@ -1,0 +1,84 @@
+import { style } from '@vanilla-extract/css';
+import { theme } from '../global.css';
+import { mediaQueries } from '@/styles/media';
+
+export const myInfoContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  margin: '0 auto',
+  paddingTop: '70px',
+
+  '@media': {
+    [mediaQueries.tablet]: {
+      paddingTop: '24px',
+    },
+  },
+});
+
+export const Container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  width: '792px',
+  height: '580px',
+  gap: '24px',
+  padding: '16px 20px',
+  '@media': {
+    [mediaQueries.tablet]: {
+      width: '429px',
+    },
+    [mediaQueries.mobile]: {
+      width: '343px',
+    },
+  },
+});
+
+export const header = style({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  width: '800px',
+  height: '48px',
+
+  '@media': {
+    [mediaQueries.tablet]: {
+      width: '429px',
+    },
+    [mediaQueries.mobile]: {
+      width: '343px',
+    },
+  },
+});
+
+export const headerTitle = style({
+  display: 'inline-block',
+  color: theme.colors.nomadBlack,
+  fontSize: theme.text['3xl-bold'].fontSize,
+  fontWeight: theme.text['3xl-bold'].fontWeight,
+  lineHeight: '38px',
+
+  '@media': {
+    [mediaQueries.tablet]: {
+      lineHeight: '42px',
+    },
+    [mediaQueries.mobile]: {
+      lineHeight: '42px',
+    },
+  },
+});
+
+export const inputContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '16px',
+});
+
+export const labelStyle = style({
+  color: theme.colors.nomadBlack,
+  fontSize: theme.text['2xl-bold'].fontSize,
+  fontWeight: theme.text['2xl-bold'].fontWeight,
+  lineHeight: theme.text['2xl-bold'].lineHeight,
+});

--- a/src/app/myPage/page.tsx
+++ b/src/app/myPage/page.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import {
+  myInfoContainer,
+  header,
+  Container,
+  headerTitle,
+  inputContainer,
+  labelStyle,
+} from './myPage.css';
+import CustomInput from '@/components/CustomInput';
+import CustomButton from '@/components/CustomButton';
+
+export default function MyPage() {
+  <div className={myInfoContainer}>
+    <div className={Container}>
+      <div className={header}>
+        <h2 className={headerTitle}>내 정보</h2>
+        <CustomButton mode="save" />
+      </div>
+      <div className={inputContainer}>
+        <label className={labelStyle}>닉네임</label>
+        <CustomInput mode="myNickname" />
+      </div>
+      <div className={inputContainer}>
+        <label className={labelStyle}>이메일</label>
+        <CustomInput mode="myEmail" />
+      </div>
+      <div className={inputContainer}>
+        <label className={labelStyle}>비밀번호</label>
+        <CustomInput mode="myPassword" />
+      </div>
+      <div className={inputContainer}>
+        <label className={labelStyle}>비밀번호 재입력</label>
+        <CustomInput mode="myPasswordConfirm" />
+      </div>
+    </div>
+  </div>;
+}

--- a/src/components/CustomInput.css.ts
+++ b/src/components/CustomInput.css.ts
@@ -5,7 +5,6 @@ import { theme } from '@/app/global.css';
 export const baseInput = style({
   color: theme.colors.nomadBlack,
   backgroundColor: theme.colors.white,
-  margin: '20px',
   borderRadius: '4px',
   outline: '1px solid theme.colors.gray2',
   padding: '16px 20px',


### PR DESCRIPTION
### Closed #이슈번호18

## 📝 Description

- 내 정보 페이지 UI 구현

## ✅ To-Do List

- [x] 내 정보(header) / 저장하기 버튼 
- [x] 닉네임 label / input
- [x] 이메일 label / input
- [x] 비밀번호 label / input
- [x] 비밀번호 재입력 label / input
- [x] 반응형  

## 📷 Screenshot

![screencapture-localhost-3000-2024-12-26-23_52_53](https://github.com/user-attachments/assets/d149d722-6f64-4087-ad64-efb41d3b682f)

