### PR TITLE
[Feat] 예약 내역 페이지 UI 구현

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,3 @@
----
-name: PR 템플릿
-about: 이 템플릿을 사용해서 PR 을 올려주세요.
-title: '[type] PR 제목'
-labels: ''
-assignees: ''
----
-
 ### Closed #이슈번호
 
 ## 📝 Description

--- a/.github/workflows/pull_request_title.yml
+++ b/.github/workflows/pull_request_title.yml
@@ -1,0 +1,33 @@
+name: Auto-generate Pull Request Title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+
+jobs:
+  set-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set Pull Request Title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ISSUE_TITLE=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.head.ref }} \
+            | jq -r '.title')
+
+          if [ -z "$ISSUE_TITLE" ] || [ "$ISSUE_TITLE" == "null" ]; then
+            ISSUE_TITLE="Default PR Title: ${GITHUB_REF#refs/heads/}"
+          fi
+
+          curl -s -X PATCH -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d "{\"title\": \"$ISSUE_TITLE\"}" \
+            https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}

--- a/src/app/myPage/components/ReservationCard.css.ts
+++ b/src/app/myPage/components/ReservationCard.css.ts
@@ -1,0 +1,153 @@
+import { style, styleVariants } from '@vanilla-extract/css';
+import { theme } from '../../global.css';
+import { mediaQueries } from '@/styles/media';
+
+export const cardContainer = style({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  justifyContent: 'center',
+  margin: '0 auto',
+});
+
+export const imageContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  position: 'relative',
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderTopLeftRadius: '24px',
+  borderBottomLeftRadius: '24px',
+  width: '204px',
+  height: '204px',
+
+  '@media': {
+    [mediaQueries.tablet]: {
+      width: '156px',
+      height: '156px',
+    },
+    [mediaQueries.mobile]: {
+      width: '128px',
+      height: '128px',
+    },
+  },
+});
+
+export const activityInfoContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-start',
+  justifyContent: 'center',
+  padding: '21px 24px',
+  '@media': {
+    [mediaQueries.tablet]: {
+      padding: '12px 16px 0px 12px',
+    },
+    [mediaQueries.mobile]: {
+      padding: '11px 1px 0px 8px',
+    },
+  },
+});
+
+export const reservationStatus1 = style({
+  fontSize: theme.text['lg-bold'].fontSize,
+  fontWeight: theme.text['lg-bold'].fontWeight,
+  lineHeight: theme.text['lg-bold'].lineHeight,
+  marginBottom: '8px',
+
+  '@media': {
+    [mediaQueries.mobile]: {
+      fontSize: theme.text['md-bold'].fontSize,
+      fontWeight: theme.text['md-bold'].fontWeight,
+      lineHeight: '26px',
+    },
+  },
+});
+
+export const reservationStatus2 = styleVariants({
+  pending: {
+    color: theme.colors.yellow1,
+  },
+
+  confirmed: {
+    color: theme.colors.orange1,
+  },
+
+  declined: {
+    color: theme.colors.red1,
+  },
+
+  canceled: {
+    color: theme.colors.gray2,
+  },
+
+  completed: {
+    color: theme.colors.blue2,
+  },
+
+  completed_experience: {
+    color: theme.colors.gray2,
+  },
+});
+
+export const activityTitle = style({
+  color: theme.colors.nomadBlack,
+  fontSize: theme.text['xl-bold'].fontSize,
+  fontWeight: theme.text['xl-bold'].fontWeight,
+  lineHeight: theme.text['xl-bold'].lineHeight,
+  marginBottom: '12px',
+
+  '@media': {
+    [mediaQueries.tablet]: {
+      fontSize: theme.text['2lg-bold'].fontSize,
+      fontWeight: theme.text['2lg-bold'].fontWeight,
+      lineHeight: theme.text['2lg-bold'].lineHeight,
+    },
+    [mediaQueries.mobile]: {
+      fontSize: theme.text['md-bold'].fontSize,
+      fontWeight: theme.text['md-bold'].fontWeight,
+      lineHeight: '26px',
+    },
+  },
+});
+
+export const activityDate = style({
+  color: theme.colors.nomadBlack,
+  fontSize: theme.text['2lg-regular'].fontSize,
+  fontWeight: theme.text['2lg-regular'].fontWeight,
+  lineHeight: theme.text['2lg-regular'].lineHeight,
+  marginBottom: '16px',
+
+  '@media': {
+    [mediaQueries.tablet]: {
+      fontSize: theme.text['md-regular'].fontSize,
+      fontWeight: theme.text['md-regular'].fontWeight,
+      lineHeight: theme.text['md-regular'].lineHeight,
+    },
+    [mediaQueries.mobile]: {
+      fontSize: theme.text['xs-regular'].fontSize,
+      fontWeight: theme.text['xs-regular'].fontWeight,
+      lineHeight: '24px',
+    },
+  },
+});
+
+export const activityPrice = style({
+  color: theme.colors.nomadBlack,
+  fontSize: theme.text['2xl-medium'].fontSize,
+  fontWeight: theme.text['2xl-medium'].fontWeight,
+  lineHeight: theme.text['2xl-medium'].lineHeight,
+
+  '@media': {
+    [mediaQueries.tablet]: {
+      fontSize: theme.text['xl-medium'].fontSize,
+      fontWeight: theme.text['xl-medium'].fontWeight,
+      lineHeight: theme.text['xl-medium'].lineHeight,
+    },
+    [mediaQueries.mobile]: {
+      fontSize: theme.text['lg-medium'].fontSize,
+      fontWeight: theme.text['lg-medium'].fontWeight,
+      lineHeight: '19px',
+    },
+  },
+});

--- a/src/app/myPage/components/ReservationCard.tsx
+++ b/src/app/myPage/components/ReservationCard.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import Image from 'next/image';
+import CustomButton from '@/components/CustomButton';
+import {
+  cardContainer,
+  imageContainer,
+  reservationStatus1,
+  reservationStatus2,
+  activityTitle,
+  activityDate,
+  activityPrice,
+  activityInfoContainer,
+} from './reservationCard.css';
+import {
+  ReservationStatus,
+  Reservations,
+  statusToButtonMode,
+} from '@/types/ReservationList';
+import { translateStatus } from '@/utils/translateStatus';
+import { isPastEvent } from '@/utils/isPastEvent';
+
+export const getStatusEnum = (
+  status: string,
+  date?: string,
+  startTime?: string
+): ReservationStatus => {
+  switch (status) {
+    case ReservationStatus.pending:
+      return ReservationStatus.pending;
+    case ReservationStatus.confirmed:
+      return ReservationStatus.confirmed;
+    case ReservationStatus.declined:
+      return ReservationStatus.declined;
+    case ReservationStatus.canceled:
+      return ReservationStatus.canceled;
+    case ReservationStatus.completed:
+      if (date && startTime && isPastEvent(date, startTime)) {
+        return ReservationStatus.completed_experience;
+      }
+      return ReservationStatus.completed;
+    default:
+      return ReservationStatus.pending;
+  }
+};
+
+export default function ReservationCard({
+  activity,
+  status,
+  totalPrice,
+  headCount,
+  date,
+  startTime,
+  endTime,
+}: Reservations) {
+  const statusEnum = getStatusEnum(status);
+
+  const statusMode = statusToButtonMode[statusEnum] ?? 'none';
+
+  const variantClass = reservationStatus2[statusEnum];
+  const combinedClassName = [reservationStatus1, variantClass].join(' ');
+
+  return (
+    <>
+      <div className={cardContainer}>
+        <div className={imageContainer}>
+          <Image src={activity.bannerImageUrl} alt={activity.title} fill />
+        </div>
+        <div className={activityInfoContainer}>
+          <p className={combinedClassName}>{translateStatus(statusEnum)}</p>
+          <h3 className={activityTitle}>{activity.title}</h3>
+          <p
+            className={activityDate}
+          >{`${date} | ${startTime} ~ ${endTime} | ${headCount}명`}</p>
+          <div>
+            <p className={activityPrice}>{`₩${totalPrice.toLocaleString()}`}</p>
+            <CustomButton mode={statusMode} />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/myPage/components/reservationsList.css.ts
+++ b/src/app/myPage/components/reservationsList.css.ts
@@ -1,0 +1,81 @@
+import { style } from '@vanilla-extract/css';
+import { theme } from '../../global.css';
+import { mediaQueries } from '@/styles/media';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  margin: '0 auto',
+});
+
+export const reservationsContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  paddingTop: '70px',
+
+  '@media': {
+    [mediaQueries.tablet]: {
+      paddingTop: '24px',
+    },
+  },
+});
+
+export const headerContainer = style({
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  marginBottom: '24px',
+
+  '@media': {
+    [mediaQueries.mobile]: {
+      marginBottom: '12px',
+    },
+  },
+});
+
+export const headerTitle = style({
+  display: 'inline-block',
+  color: theme.colors.nomadBlack,
+  fontSize: theme.text['3xl-bold'].fontSize,
+  fontWeight: theme.text['3xl-bold'].fontWeight,
+  lineHeight: '38px',
+});
+
+export const statusFilter = style({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'left',
+  padding: '13.5px 20px',
+  gap: '8px',
+  width: '160px',
+  height: '53px',
+  outline: '1px solid theme.colors.green1',
+  ...theme.text['2lg-medium'],
+  color: theme.colors.green1,
+});
+
+export const statusFilterOptions = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: '18px 46.5px',
+  gap: '8px',
+  width: '160px',
+  height: '53px',
+  ...theme.text['2lg-medium'],
+  color: theme.colors.gray1,
+});
+
+export const reservationList = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '24px',
+  width: '100%',
+});

--- a/src/app/myPage/components/reservationsList.tsx
+++ b/src/app/myPage/components/reservationsList.tsx
@@ -1,0 +1,94 @@
+import React, { useState, useEffect } from 'react';
+import ReservationCard from './reservationCard';
+import {
+  reservationsContainer,
+  container,
+  headerTitle,
+  headerContainer,
+  statusFilter,
+  statusFilterOptions,
+  reservationList,
+} from './reservationsList.css';
+import { ReservationStatus, Reservations } from '@/types/ReservationList';
+import { isPastEvent } from '@/utils/isPastEvent';
+import { FIXED_OPTIONS } from '@/utils/translateStatus';
+
+export default function ReservationsList() {
+  const [reservations, setReservations] = useState<Reservations[]>([]);
+  const [selectedStatus, setSelectedStatus] = useState<string>('');
+
+  useEffect(() => {
+    async function fetchReservationsByStatus(statusValue: string) {
+      try {
+        const apiStatus =
+          statusValue === 'completed_experience' ? 'completed' : statusValue;
+
+        let url = 'https://sp-globalnomad-api.vercel.app/10-2/my-reservations';
+        if (apiStatus) {
+          url += `?status=${apiStatus}`;
+        }
+
+        const res = await fetch(url);
+        if (!res.ok) {
+          throw new Error('Failed to fetch reservations');
+        }
+
+        const data = await res.json();
+        let fetchedReservations: Reservations[] = data.reservations;
+
+        if (statusValue === 'completed_experience') {
+          fetchedReservations = fetchedReservations.filter((r) =>
+            isPastEvent(r.date, r.startTime)
+          );
+        }
+
+        setReservations(fetchedReservations);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+
+    fetchReservationsByStatus(selectedStatus);
+  }, [selectedStatus]);
+
+  function handleStatusChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    setSelectedStatus(e.target.value as ReservationStatus | '');
+  }
+
+  const filteredReservations = reservations.filter((res) => {
+    if (!selectedStatus) return true;
+    return res.status === selectedStatus;
+  });
+
+  return (
+    <div className={container}>
+      <div className={reservationsContainer}>
+        <div className={headerContainer}>
+          <h2 className={headerTitle}>예약 내역</h2>
+          <label className={statusFilter}>필터</label>
+          <select
+            className={statusFilterOptions}
+            value={selectedStatus}
+            onChange={handleStatusChange}
+          >
+            {FIXED_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className={reservationList}>
+          {reservations.map((r) => (
+            <ReservationCard key={r.id} {...r} />
+          ))}
+
+          {filteredReservations.length === 0 && (
+            <p>아직 등록한 체험이 없어요</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/myPage/myPage.css.ts
+++ b/src/app/myPage/myPage.css.ts
@@ -2,7 +2,7 @@ import { style } from '@vanilla-extract/css';
 import { theme } from '../global.css';
 import { mediaQueries } from '@/styles/media';
 
-export const myInfoContainer = style({
+export const Container = style({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
@@ -17,7 +17,7 @@ export const myInfoContainer = style({
   },
 });
 
-export const Container = style({
+export const myInfoContainer = style({
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'center',

--- a/src/app/myPage/page.tsx
+++ b/src/app/myPage/page.tsx
@@ -11,28 +11,30 @@ import CustomInput from '@/components/CustomInput';
 import CustomButton from '@/components/CustomButton';
 
 export default function MyPage() {
-  <div className={myInfoContainer}>
+  return (
     <div className={Container}>
-      <div className={header}>
-        <h2 className={headerTitle}>내 정보</h2>
-        <CustomButton mode="save" />
-      </div>
-      <div className={inputContainer}>
-        <label className={labelStyle}>닉네임</label>
-        <CustomInput mode="myNickname" />
-      </div>
-      <div className={inputContainer}>
-        <label className={labelStyle}>이메일</label>
-        <CustomInput mode="myEmail" />
-      </div>
-      <div className={inputContainer}>
-        <label className={labelStyle}>비밀번호</label>
-        <CustomInput mode="myPassword" />
-      </div>
-      <div className={inputContainer}>
-        <label className={labelStyle}>비밀번호 재입력</label>
-        <CustomInput mode="myPasswordConfirm" />
+      <div className={myInfoContainer}>
+        <div className={header}>
+          <h2 className={headerTitle}>내 정보</h2>
+          <CustomButton mode="save" />
+        </div>
+        <div className={inputContainer}>
+          <label className={labelStyle}>닉네임</label>
+          <CustomInput mode="myNickname" />
+        </div>
+        <div className={inputContainer}>
+          <label className={labelStyle}>이메일</label>
+          <CustomInput mode="myEmail" />
+        </div>
+        <div className={inputContainer}>
+          <label className={labelStyle}>비밀번호</label>
+          <CustomInput mode="myPassword" />
+        </div>
+        <div className={inputContainer}>
+          <label className={labelStyle}>비밀번호 재입력</label>
+          <CustomInput mode="myPasswordConfirm" />
+        </div>
       </div>
     </div>
-  </div>;
+  );
 }

--- a/src/components/CustomButton.css.ts
+++ b/src/components/CustomButton.css.ts
@@ -207,4 +207,12 @@ export const buttonVariants = styleVariants({
       },
     },
   },
+
+  none: {
+    width: '120px',
+    height: '48px',
+    borderRadius: '8px',
+    backgroundColor: theme.colors.white,
+    color: theme.colors.white,
+  },
 });

--- a/src/types/CustomButtonMode.ts
+++ b/src/types/CustomButtonMode.ts
@@ -14,7 +14,8 @@ export type CustomButtonMode =
   | 'reservationReject'
   | 'reservationConfirmed'
   | 'reservationDenied'
-  | 'check';
+  | 'check'
+  | 'none';
 
 export const modeTextMap: Record<CustomButtonMode, string> = {
   login: '로그인하기',
@@ -33,4 +34,5 @@ export const modeTextMap: Record<CustomButtonMode, string> = {
   reservationConfirmed: '예약 확정',
   reservationDenied: '예약 거절',
   check: '확인', // 단순 팝업창 확인
+  none: '',
 };

--- a/src/types/ReservationList.ts
+++ b/src/types/ReservationList.ts
@@ -1,0 +1,55 @@
+export enum ReservationStatus {
+  pending = 'pending',
+  confirmed = 'confirmed',
+  declined = 'declined',
+  canceled = 'canceled',
+  completed = 'completed',
+  completed_experience = 'completed_experience',
+}
+
+export const STATUS_LIST: ReservationStatus[] = [
+  ReservationStatus.pending,
+  ReservationStatus.confirmed,
+  ReservationStatus.declined,
+  ReservationStatus.canceled,
+  ReservationStatus.completed,
+  ReservationStatus.completed_experience,
+];
+
+export interface Reservations {
+  id: number;
+  teamId: string;
+  userId: number;
+  activity: {
+    bannerImageUrl: string;
+    title: string;
+    id: number;
+  };
+  scheduleId: number;
+  status: string;
+  reviewSubmitted: boolean;
+  totalPrice: number;
+  headCount: number;
+  date: string;
+  startTime: string;
+  endTime: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface MyReservations {
+  cursorId: number;
+  reservations: Reservations[];
+  totalCount: number;
+}
+
+export type ButtonMode = 'none' | 'reservationCancel' | 'writeReview';
+
+export const statusToButtonMode: Record<ReservationStatus, ButtonMode> = {
+  [ReservationStatus.pending]: 'reservationCancel',
+  [ReservationStatus.confirmed]: 'reservationCancel',
+  [ReservationStatus.declined]: 'none',
+  [ReservationStatus.canceled]: 'none',
+  [ReservationStatus.completed]: 'reservationCancel',
+  [ReservationStatus.completed_experience]: 'writeReview',
+};

--- a/src/utils/isPastEvent.ts
+++ b/src/utils/isPastEvent.ts
@@ -1,0 +1,7 @@
+export function isPastEvent(dateString: string, timeString: string): boolean {
+  const [year, month, day] = dateString.split('.').map(Number);
+  const [hour, minute] = timeString.split(':').map(Number);
+  const eventDate = new Date(year, month - 1, day, hour, minute);
+
+  return eventDate.getTime() < Date.now();
+}

--- a/src/utils/translateStatus.ts
+++ b/src/utils/translateStatus.ts
@@ -1,0 +1,30 @@
+import { ReservationStatus } from '@/types/ReservationList';
+
+export const translateStatus = (status: ReservationStatus) => {
+  switch (status) {
+    case ReservationStatus.pending:
+      return '예약 신청';
+    case ReservationStatus.confirmed:
+      return '예약 승인';
+    case ReservationStatus.declined:
+      return '예약 거절';
+    case ReservationStatus.canceled:
+      return '예약 취소';
+    case ReservationStatus.completed:
+      return '예약 완료';
+    case ReservationStatus.completed_experience:
+      return '체험 완료';
+    default:
+      return '';
+  }
+};
+
+export const FIXED_OPTIONS = [
+  { label: '전체', value: '' },
+  { label: '예약 신청', value: 'pending' },
+  { label: '예약 승인', value: 'confirmed' },
+  { label: '예약 거절', value: 'declined' },
+  { label: '예약 취소', value: 'canceled' },
+  { label: '예약 완료', value: 'completed' },
+  { label: '체험 완료', value: 'completed_experience' },
+];


### PR DESCRIPTION
### Closed #22

## 📝 Description

-  예약 내역 페이지 UI 구현
-  CustomButton 코드 일부 추가 :  none 버튼 모드 추가 (보이지 않는 버튼)
-  PR 제목 자동 생성 관련 코드 추가 
-  PR 템플릿 일부 수정
-  myPage/page.tsx : return 문 추가

## ✅ To-Do List

- [x] 예약 내역(header)  필터(드롭다운)
- [x] 예약 리스트 
- [x] 예약 리스트 - [예약 신청 / 예약 승인 / 예약 거절 / 예약 취소 / 예약 완료 / 체험 완료] 상태 표시
- [x] 예약 리스트 - 체험 제목 
- [x] 예약 리스트 - 기간 * 인원
- [x] 예약 리스트 - 금액  [후기작성 버튼 / 예약 취소 버튼 / (none) 버튼]

## 📷 Screenshot
